### PR TITLE
Enable some kernel harden cmdline flags

### DIFF
--- a/Scripts/Common/Functions.sh
+++ b/Scripts/Common/Functions.sh
@@ -533,7 +533,7 @@ export -f hardenUserdata;
 
 hardenBootArgs() {
 	cd "$DOS_BUILD_BASE$1";
-	sed -i 's/BOARD_KERNEL_CMDLINE := /BOARD_KERNEL_CMDLINE := slub_debug=FZP /' BoardConfig*.mk */BoardConfig*.mk &>/dev/null || true; #TODO: inline this
+	sed -i 's/BOARD_KERNEL_CMDLINE := /BOARD_KERNEL_CMDLINE := init_on_alloc=1 init_on_free=1 page_alloc.shuffle=1 page_poison=1 kpti=on randomize_kstack_offset=on slab_nomerge slub_debug=FZP /' BoardConfig*.mk */BoardConfig*.mk &>/dev/null || true; #TODO: inline this
 	echo "Hardened kernel command line arguments for $1";
 	cd "$DOS_BUILD_BASE";
 }


### PR DESCRIPTION
This enables some kernel feature for making exploits more difficult.
They are documented here [0].
I don't think they break a device, but I don't know since I just tested them on my cheeseburger.

[0] https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html

