### PR TITLE
Functions.sh: fix source not found

### DIFF
--- a/Scripts/Common/Functions.sh
+++ b/Scripts/Common/Functions.sh
@@ -33,7 +33,7 @@ patchWorkspace() {
 export -f patchWorkspace;
 
 verifyAllPlatformTags() {
-	repo forall -c 'source $DOS_WORKSPACE_ROOT/Scripts/Common/Tag_Verifier.sh && verifyTagIfPlatform $REPO_PROJECT $REPO_PATH';
+	repo forall -v -c 'sh -c "source $DOS_WORKSPACE_ROOT/Scripts/Common/Tag_Verifier.sh && verifyTagIfPlatform $REPO_PROJECT $REPO_PATH"';
 }
 export -f verifyAllPlatformTags;
 


### PR DESCRIPTION
Fixes the following issue on systems where /bin/sh != /bin/bash (e.g. Ubuntu):

> source [...]/Scripts/Common/Tag_Verifier.sh && verifyTagIfPlatform  : 1: source: not found

for these (unsupported) systems the following is still required (not needed on Fedora or other systems using /bin/sh -> /bin/bash):
 
1. `ln -s /bin/bash ~/.local/bin/sh`
2. .bashrc -> `export PATH="$HOME/.local/bin:$PATH"`
3. .bashrc -> `alias sh='/bin/bash'`