### PR TITLE
allow to specify thread counts (sync,build)

### DIFF
--- a/Scripts/Common/Functions.sh
+++ b/Scripts/Common/Functions.sh
@@ -23,7 +23,7 @@ export -f startPatcher;
 
 resetWorkspace() {
 	umask 0022;
-	repo forall -c 'git add -A && git reset --hard' && rm -rf out DOS_PATCHED_FLAG && repo sync -j8 --force-sync --detach;
+	repo forall -j${DOS_MAX_THREADS_REPO} -c 'git add -A && git reset --hard' && rm -rf out DOS_PATCHED_FLAG && repo sync -j${DOS_MAX_THREADS_REPO} --force-sync --detach;
 }
 export -f resetWorkspace;
 
@@ -33,7 +33,7 @@ patchWorkspace() {
 export -f patchWorkspace;
 
 verifyAllPlatformTags() {
-	repo forall -v -c 'sh -c "source $DOS_WORKSPACE_ROOT/Scripts/Common/Tag_Verifier.sh && verifyTagIfPlatform $REPO_PROJECT $REPO_PATH"';
+	repo forall -j${DOS_MAX_THREADS_REPO} -v -c 'sh -c "source $DOS_WORKSPACE_ROOT/Scripts/Common/Tag_Verifier.sh && verifyTagIfPlatform $REPO_PROJECT $REPO_PATH"';
 }
 export -f verifyAllPlatformTags;
 

--- a/Scripts/LineageOS-14.1/Functions.sh
+++ b/Scripts/LineageOS-14.1/Functions.sh
@@ -34,7 +34,7 @@ buildDevice() {
 	cd "$DOS_BUILD_BASE";
 	export OTA_KEY_OVERRIDE_DIR="$DOS_SIGNING_KEYS/$1";
 	pkill java && sleep 10; #XXX: ugly hack
-	breakfast "lineage_$1-user" && mka target-files-package otatools && processRelease $1 true $2;
+	breakfast "lineage_$1-user" && mka -j${DOS_MAX_THREADS_BUILD} target-files-package otatools && processRelease $1 true $2;
 	pkill java && sleep 10; #XXX: ugly hack
 }
 export -f buildDevice;
@@ -43,7 +43,7 @@ buildDeviceUserDebug() {
 	cd "$DOS_BUILD_BASE";
 	if [[ -d "$DOS_SIGNING_KEYS/$1" ]]; then
 		export OTA_KEY_OVERRIDE_DIR="$DOS_SIGNING_KEYS/$1";
-		breakfast "lineage_$1-userdebug" && mka target-files-package otatools && processRelease $1 true $2;
+		breakfast "lineage_$1-userdebug" && mka -j${DOS_MAX_THREADS_BUILD} target-files-package otatools && processRelease $1 true $2;
 	else
 		echo -e "\e[0;31mNo signing keys available for $1\e[0m";
 	fi;

--- a/Scripts/LineageOS-15.1/Functions.sh
+++ b/Scripts/LineageOS-15.1/Functions.sh
@@ -34,7 +34,7 @@ buildDevice() {
 	cd "$DOS_BUILD_BASE";
 	if [[ -d "$DOS_SIGNING_KEYS/$1" ]]; then
 		export OTA_KEY_OVERRIDE_DIR="$DOS_SIGNING_KEYS/$1";
-		breakfast "lineage_$1-user" && mka target-files-package otatools && processRelease $1 true $2;
+		breakfast "lineage_$1-user" && mka -j${DOS_MAX_THREADS_BUILD} target-files-package otatools && processRelease $1 true $2;
 	else
 		echo -e "\e[0;31mNo signing keys available for $1\e[0m";
 	fi;

--- a/Scripts/LineageOS-16.0/Functions.sh
+++ b/Scripts/LineageOS-16.0/Functions.sh
@@ -34,7 +34,7 @@ buildDevice() {
 	cd "$DOS_BUILD_BASE";
 	if [[ -d "$DOS_SIGNING_KEYS/$1" ]]; then
 		export OTA_KEY_OVERRIDE_DIR="$DOS_SIGNING_KEYS/$1";
-		breakfast "lineage_$1-user" && mka target-files-package otatools && processRelease $1 true $2;
+		breakfast "lineage_$1-user" && mka -j${DOS_MAX_THREADS_BUILD} target-files-package otatools && processRelease $1 true $2;
 	else
 		echo -e "\e[0;31mNo signing keys available for $1\e[0m";
 	fi;

--- a/Scripts/LineageOS-17.1/Functions.sh
+++ b/Scripts/LineageOS-17.1/Functions.sh
@@ -34,7 +34,7 @@ buildDevice() {
 	cd "$DOS_BUILD_BASE";
 	if [[ -d "$DOS_SIGNING_KEYS/$1" ]]; then
 		export OTA_KEY_OVERRIDE_DIR="$DOS_SIGNING_KEYS/$1";
-		breakfast "lineage_$1-user" && mka target-files-package otatools && processRelease $1 true $2;
+		breakfast "lineage_$1-user" && mka -j${DOS_MAX_THREADS_BUILD} target-files-package otatools && processRelease $1 true $2;
 	else
 		echo -e "\e[0;31mNo signing keys available for $1\e[0m";
 	fi;

--- a/Scripts/LineageOS-18.1/Functions.sh
+++ b/Scripts/LineageOS-18.1/Functions.sh
@@ -34,7 +34,7 @@ buildDevice() {
 	cd "$DOS_BUILD_BASE";
 	if [[ -d "$DOS_SIGNING_KEYS/$1" ]]; then
 		export OTA_KEY_OVERRIDE_DIR="$DOS_SIGNING_KEYS/$1";
-		breakfast "lineage_$1-user" && mka target-files-package otatools && processRelease $1 true $2;
+		breakfast "lineage_$1-user" && mka -j${DOS_MAX_THREADS_BUILD} target-files-package otatools && processRelease $1 true $2;
 	else
 		echo -e "\e[0;31mNo signing keys available for $1\e[0m";
 	fi;

--- a/Scripts/LineageOS-19.1/Functions.sh
+++ b/Scripts/LineageOS-19.1/Functions.sh
@@ -34,7 +34,7 @@ buildDevice() {
 	cd "$DOS_BUILD_BASE";
 	if [[ -d "$DOS_SIGNING_KEYS/$1" ]]; then
 		export OTA_KEY_OVERRIDE_DIR="$DOS_SIGNING_KEYS/$1";
-		breakfast "lineage_$1-user" && mka target-files-package otatools && processRelease $1 true $2;
+		breakfast "lineage_$1-user" && mka -j${DOS_MAX_THREADS_BUILD} target-files-package otatools && processRelease $1 true $2;
 	else
 		echo -e "\e[0;31mNo signing keys available for $1\e[0m";
 	fi;

--- a/Scripts/LineageOS-20.0/Functions.sh
+++ b/Scripts/LineageOS-20.0/Functions.sh
@@ -34,7 +34,7 @@ buildDevice() {
 	cd "$DOS_BUILD_BASE";
 	if [[ -d "$DOS_SIGNING_KEYS/$1" ]]; then
 		#export OTA_KEY_OVERRIDE_DIR="$DOS_SIGNING_KEYS/$1";
-		breakfast "lineage_$1-user" && mka target-files-package otatools && processRelease $1 true $2;
+		breakfast "lineage_$1-user" && mka -j${DOS_MAX_THREADS_BUILD} target-files-package otatools && processRelease $1 true $2;
 	else
 		echo -e "\e[0;31mNo signing keys available for $1\e[0m";
 	fi;


### PR DESCRIPTION
when DOS_MAX_THREADS_REPO and/or DOS_MAX_THREADS_BUILD are defined in init.sh they will be used. otherwise the max threads are calculated based on the cpu cores count.

if that calculation fails (depends on nproc) a default fallback of:

- 4 is used for repo sync (which reflects the current state for repo sync)
- `<empty>` is used for make - which yields to no limitation (which reflects the current state for mka / make)

to avoid issues regarding being rate limited a max value for repo sync processes will overwrite DOS_MAX_THREADS_REPO when set greater than MAX_THREADS_REPO_RATE (8).