### PR TITLE
support per device config

### DIFF
--- a/Scripts/init.sh
+++ b/Scripts/init.sh
@@ -106,6 +106,7 @@ export DOS_THEME_700="E64A19"; #Deep Orange 700
 #
 #END OF USER CONFIGURABLE OPTIONS
 #
+[ -f "$HOME/.divested.vars.${BDEVICE}" ] && source $HOME/.divested.vars.${BDEVICE} && echo "included $HOME/.divested.vars.${BDEVICE} config"
 
 umask 0022;
 

--- a/Scripts/init.sh
+++ b/Scripts/init.sh
@@ -106,6 +106,7 @@ export DOS_THEME_700="E64A19"; #Deep Orange 700
 #
 #END OF USER CONFIGURABLE OPTIONS
 #
+[ -f "$HOME/.divested.vars" ] && source $HOME/.divested.vars && echo "included $HOME/.divested.vars config"
 [ -f "$HOME/.divested.vars.${BDEVICE}" ] && source $HOME/.divested.vars.${BDEVICE} && echo "included $HOME/.divested.vars.${BDEVICE} config"
 
 umask 0022;


### PR DESCRIPTION
when the file `~/.divested.vars.${BDEVICE}` exists it get sourced after the default variables set by init.sh.

so to make use of this you have to

`export BDEVICE=hotdog`

before `source ../Scripts/init.sh`. Then the file `~/.divested.vars.hotdog` will be sourced - if existent.

this way one can:

- override defaults without touching the init.sh (makes git pull more convenient)
- set different settings for different devices