### PR TITLE
fix an issue when no delta requested

### DIFF
--- a/Scripts/Common/Functions.sh
+++ b/Scripts/Common/Functions.sh
@@ -406,11 +406,11 @@ processRelease() {
 		if [[ " ${DOS_GENERATE_DELTAS_DEVICES[@]} " =~ " ${DEVICE} " ]]; then cp -v $OUT_DIR/$PREFIX-target_files.zip* $ARCHIVE/target_files/; fi;
 		cp -v $OUT_DIR/$PREFIX-fastboot.zip* $ARCHIVE/fastboot/ || true;
 		cp -v $OUT_DIR/$PREFIX-ota.zip* $ARCHIVE/;
-		cp -v $OUT_DIR/$PREFIX-incremental_*.zip* $ARCHIVE/incrementals/ || true;
+		if [[ " ${DOS_GENERATE_DELTAS} " == true ]]; then cp -v $OUT_DIR/$PREFIX-incremental_*.zip* $ARCHIVE/incrementals/ || true; fi
 		cp -v $OUT_DIR/$PREFIX-recovery.img* $ARCHIVE/ || true;
 
 		rename -- "-ota." "." $ARCHIVE/$PREFIX-ota.zip*;
-		rename -- "-incremental_" "-" $ARCHIVE/incrementals/$PREFIX-incremental_*.zip*;
+		[[ " ${DOS_GENERATE_DELTAS} " == true ]] && rename -- "-incremental_" "-" $ARCHIVE/incrementals/$PREFIX-incremental_*.zip*;
 		sync;
 
 		#Remove to make space for next build


### PR DESCRIPTION
this one will break the build when using https://github.com/Divested-Mobile/DivestOS-Build/pull/206 :

> rename: /ssd/tmp/dos/hotdog/LineageOS-20.0/release_keys//incrementals/xxxx-20.0-20230713-dos-hotdog-incremental_*.zip*: not accessible: No such file or directory

the next one is a cosmetic thing only. while the current implementation does not break the build I prefer skipping it if not needed at all instead of just the `|| true`  workaround. "fixes" the message in build output when no delta is requested:

> cp: cannot stat 'xxxx-20.0-20230713-dos-hotdog-incremental_*.zip*': No such file or directory