### PR TITLE
fixup rebrand for recovery

### DIFF
--- a/Scripts/LineageOS-17.1/Rebrand.sh
+++ b/Scripts/LineageOS-17.1/Rebrand.sh
@@ -37,7 +37,7 @@ sed -i 's|0xfd, 0xd8,0x35|0x8b, 0xc3, 0x4a|' recovery_ui/*ui.cpp; #Recolor accen
 sed -i 's|0x16, 0x7c, 0x80|0x03, 0xa9, 0xf4|' recovery_ui/*ui.cpp; #Recolor text
 sed -i 's|Android Recovery|'"$DOS_BRANDING_NAME"' Recovery|' recovery_ui/*ui.cpp;
 sed -i 's|LineageOS|'"$DOS_BRANDING_NAME"'|' recovery_ui/*ui.cpp;
-sed -i 's|Lineage |'"$DOS_BRANDING_NAME"' |' recovery.cpp;
+sed -i 's|"Version "|"'$DOS_BRANDING_NAME' "|' recovery.cpp
 fi;
 
 if enter "build/make"; then

--- a/Scripts/LineageOS-18.1/Rebrand.sh
+++ b/Scripts/LineageOS-18.1/Rebrand.sh
@@ -36,7 +36,7 @@ sed -i 's|0xfd, 0xd8,0x35|0x8b, 0xc3, 0x4a|' recovery_ui/*ui.cpp; #Recolor accen
 sed -i 's|0x16, 0x7c, 0x80|0x03, 0xa9, 0xf4|' recovery_ui/*ui.cpp; #Recolor text
 sed -i 's|Android Recovery|'"$DOS_BRANDING_NAME"' Recovery|' recovery_ui/*ui.cpp;
 sed -i 's|LineageOS|'"$DOS_BRANDING_NAME"'|' recovery_ui/*ui.cpp;
-sed -i 's|Lineage |'"$DOS_BRANDING_NAME"' |' recovery.cpp;
+sed -i 's|"Version "|"'$DOS_BRANDING_NAME' "|' recovery.cpp
 fi;
 
 if enter "build/make"; then

--- a/Scripts/LineageOS-19.1/Rebrand.sh
+++ b/Scripts/LineageOS-19.1/Rebrand.sh
@@ -36,7 +36,7 @@ sed -i 's|0xfd, 0xd8,0x35|0x8b, 0xc3, 0x4a|' recovery_ui/*ui.cpp; #Recolor accen
 sed -i 's|0x16, 0x7c, 0x80|0x03, 0xa9, 0xf4|' recovery_ui/*ui.cpp; #Recolor text
 sed -i 's|Android Recovery|'"$DOS_BRANDING_NAME"' Recovery|' recovery_ui/*ui.cpp; #not used (yet)
 sed -i 's|LineageOS|'"$DOS_BRANDING_NAME"'|' recovery_ui/*ui.cpp; #not used (yet)
-sed -i 's|Lineage |'"$DOS_BRANDING_NAME"' |' recovery.cpp; #not used (yet)
+sed -i 's|"Version "|"'$DOS_BRANDING_NAME' "|' recovery.cpp
 fi;
 
 if enter "build/make"; then

--- a/Scripts/LineageOS-20.0/Rebrand.sh
+++ b/Scripts/LineageOS-20.0/Rebrand.sh
@@ -36,7 +36,7 @@ sed -i 's|0xfd, 0xd8,0x35|0x8b, 0xc3, 0x4a|' recovery_ui/*ui.cpp; #Recolor accen
 sed -i 's|0x16, 0x7c, 0x80|0x03, 0xa9, 0xf4|' recovery_ui/*ui.cpp; #Recolor text
 sed -i 's|Android Recovery|'"$DOS_BRANDING_NAME"' Recovery|' recovery_ui/*ui.cpp; #not used (yet)
 sed -i 's|LineageOS|'"$DOS_BRANDING_NAME"'|' recovery_ui/*ui.cpp; #not used (yet)
-sed -i 's|Lineage |'"$DOS_BRANDING_NAME"' |' recovery.cpp; #not used (yet)
+sed -i 's|"Version "|"'$DOS_BRANDING_NAME' "|' recovery.cpp
 fi;
 
 if enter "build/make"; then


### PR DESCRIPTION
only relevant for 17.1 -> 20.0 because the older ones seems to be fine (can't test those but from the source code at least)