### PR TITLE
Fixup microg signinginfo reverts

### DIFF
--- a/Scripts/LineageOS-19.1/Patch.sh
+++ b/Scripts/LineageOS-19.1/Patch.sh
@@ -133,6 +133,7 @@ sed -i '11iLOCAL_OVERRIDES_PACKAGES := Camera Camera2 LegacyCamera Snap OpenCame
 fi;
 
 if enterAndClear "frameworks/base"; then
+git revert --no-edit 74e3943cad42aa290e0e1bca593b0e9a356b72b3; #Reverts "Allow spoofing signingInfo for microG Companion/Services" in favor of below patch
 git revert --no-edit 83fe523914728a3674debba17a6019cb74803045; #Reverts "Allow signature spoofing for microG Companion/Services" in favor of below patch
 applyPatch "$DOS_PATCHES/android_frameworks_base/344888-backport.patch"; #fixup! fw/b: Add support for allowing/disallowing apps on cellular, vpn and wifi networks (CalyxOS)
 applyPatch "$DOS_PATCHES/android_frameworks_base/0007-Always_Restict_Serial.patch"; #Always restrict access to Build.SERIAL (GrapheneOS)

--- a/Scripts/LineageOS-20.0/Patch.sh
+++ b/Scripts/LineageOS-20.0/Patch.sh
@@ -128,6 +128,7 @@ fi;
 if enterAndClear "frameworks/base"; then
 git revert --no-edit d36faad3267522c6d3ff91ba9dcca8f6274bccd1; #Reverts "JobScheduler: Respect allow-in-power-save perm" in favor of below patch
 git revert --no-edit 90d6826548189ca850d91692e71fcc1be426f453; #Reverts "Remove sensitive info from SUPL requests" in favor of below patch
+git revert --no-edit 53e2f4b85ce836360dd58bdb2f0d7f42dc796443; #Reverts "Allow spoofing signingInfo for microG Companion/Services" in favor of below patch
 git revert --no-edit 6d2955f0bd55e9938d5d49415182c27b50900b95; #Reverts "Allow signature spoofing for microG Companion/Services" in favor of below patch
 applyPatch "$DOS_PATCHES/android_frameworks_base/0007-Always_Restict_Serial.patch"; #Always restrict access to Build.SERIAL (GrapheneOS)
 applyPatch "$DOS_PATCHES/android_frameworks_base/0008-Browser_No_Location.patch"; #Don't grant location permission to system browsers (GrapheneOS)

--- a/Scripts/LineageOS-21.0/Patch.sh
+++ b/Scripts/LineageOS-21.0/Patch.sh
@@ -132,6 +132,7 @@ fi;
 
 if enterAndClear "frameworks/base"; then 
 git revert --no-edit f9b5586a3887e70aa5580f8073611826eed2b88f; #Reverts "Remove sensitive info from SUPL requests" in favor of below patch
+git revert --no-edit a2b52bdf99f03afe2e36d49fa2b30ffe5bf58a5c; #Reverts "Allow spoofing signingInfo for microG Companion/Services" in favor of below patch
 git revert --no-edit 18f3b5a2615efe61636ff952b500b19d891bdc80; #Reverts "fixup! Allow signature spoofing for microG Companion/Services" in favor of below patch
 applyPatch "$DOS_PATCHES/android_frameworks_base/revert-6b793fa9.patch"; #Reverts "Allow signature spoofing for microG Companion/Services" in favor of below patch
 applyPatch "$DOS_PATCHES/android_frameworks_base/0007-Always_Restict_Serial.patch"; #Always restrict access to Build.SERIAL (GrapheneOS)


### PR DESCRIPTION
details: https://github.com/sfX-android/android_vendor_extendrom/issues/48

this updates the needed reverts. this does not touch the divest patches for implementing the new method though.
as Lineage does not support 18.1 anymore the patch wasn't backported there - but that might still happen in the future 